### PR TITLE
Fix inactive image loading

### DIFF
--- a/lib/re/listings/listings.ex
+++ b/lib/re/listings/listings.ex
@@ -20,7 +20,7 @@ defmodule Re.Listings do
   defdelegate authorize(action, user, params), to: Re.Listings.Policy
 
   @active_listings_query from(l in Listing, where: l.is_active == true)
-  @order_by_position from(i in Image, order_by: i.position)
+  @order_by_position from(i in Image, where: i.is_active == true, order_by: i.position)
 
   def paginated(params) do
     @active_listings_query

--- a/lib/re/listings/listings.ex
+++ b/lib/re/listings/listings.ex
@@ -41,13 +41,21 @@ defmodule Re.Listings do
   end
 
   def get(id) do
-    case Repo.get(@active_listings_query, id) do
+    get(Listing, id)
+  end
+
+  def get_preloaded(id) do
+    @active_listings_query
+    |> preload([:address, images: ^@order_by_position])
+    |> get(id)
+  end
+
+  defp get(query, id) do
+    case Repo.get(query, id) do
       nil -> {:error, :not_found}
       listing -> {:ok, listing}
     end
   end
-
-  def preload(listing), do: {:ok, Repo.preload(listing, [:address, images: @order_by_position])}
 
   def insert(listing_params, address_id, user_id) do
     listing_params =

--- a/lib/re_web/controllers/listing_controller.ex
+++ b/lib/re_web/controllers/listing_controller.ex
@@ -39,21 +39,18 @@ defmodule ReWeb.ListingController do
   end
 
   def show(conn, %{"id" => id}, _user) do
-    with {:ok, listing} <- Listings.get(id),
-         {:ok, listing} <- Listings.preload(listing),
+    with {:ok, listing} <- Listings.get_preloaded(id),
          do: render(conn, "show.json", listing: listing)
   end
 
   def edit(conn, %{"id" => id}, user) do
-    with {:ok, listing} <- Listings.get(id),
-         {:ok, listing} <- Listings.preload(listing),
+    with {:ok, listing} <- Listings.get_preloaded(id),
          :ok <- Bodyguard.permit(Listings, :edit_listing, user, listing),
          do: render(conn, "edit.json", listing: listing)
   end
 
   def update(conn, %{"id" => id, "listing" => listing_params, "address" => address_params}, user) do
-    with {:ok, listing} <- Listings.get(id),
-         {:ok, listing} <- Listings.preload(listing),
+    with {:ok, listing} <- Listings.get_preloaded(id),
          :ok <- Bodyguard.permit(Listings, :update_listing, user, listing),
          {:ok, address} <- Addresses.update(listing, address_params),
          {:ok, listing} <- Listings.update(listing, listing_params, address.id),

--- a/test/re_web/controllers/listing_controller_test.exs
+++ b/test/re_web/controllers/listing_controller_test.exs
@@ -210,6 +210,20 @@ defmodule ReWeb.ListingControllerTest do
       conn = get(conn, listing_path(conn, :show, listing))
       json_response(conn, 200)
     end
+
+    test "do not show inactive image", %{
+      unauthenticated_conn: conn,
+      admin_user: user
+    } do
+      %{id: id1} = image1 = insert(:image, position: 1)
+      %{id: id2} = image2 = insert(:image, position: 2)
+      image3 = insert(:image, is_active: false)
+      listing = insert(:listing, images: [image1, image2, image3], address: build(:address), user: user)
+
+      conn = get(conn, listing_path(conn, :show, listing))
+      response = json_response(conn, 200)
+      assert [%{"id" => ^id1}, %{"id" => ^id2}] = response["listing"]["images"]
+    end
   end
 
   describe "edit" do


### PR DESCRIPTION
- Fix preload query to load only active images
- Separate `get` functions in listing to preload/not preload
- Preload resources in one query instead of separated ones