### PR TITLE
Save listing views

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -34,3 +34,5 @@ config :re, Re.Repo,
   pool: Ecto.Adapters.SQL.Sandbox
 
 config :re, ReWeb.Mailer, adapter: Swoosh.Adapters.Test
+
+config :re, :visualizations, Re.TestVisualizations

--- a/lib/re/application.ex
+++ b/lib/re/application.ex
@@ -6,30 +6,21 @@ defmodule Re.Application do
   use Application
 
   alias ReWeb.Endpoint
+  alias Re.Stats.Visualizations
 
-  # See http://elixir-lang.org/docs/stable/elixir/Application.html
-  # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec
 
-    # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
       supervisor(Re.Repo, []),
-      # Start the endpoint when the application starts
-      supervisor(ReWeb.Endpoint, [])
-      # Start your own worker by calling: Re.Worker.start_link(arg1, arg2, arg3)
-      # worker(Re.Worker, [arg1, arg2, arg3]),
+      supervisor(ReWeb.Endpoint, []),
+      worker(Visualizations, [])
     ]
 
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Re.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   def config_change(changed, _new, removed) do
     Endpoint.config_change(changed, removed)
     :ok

--- a/lib/re/stats/listing_visualization.ex
+++ b/lib/re/stats/listing_visualization.ex
@@ -1,0 +1,26 @@
+defmodule Re.Stats.ListingVisualization do
+  @moduledoc """
+  Model to record listing visualizations
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  schema "listing_visualizations" do
+    field(:details, :map)
+
+    belongs_to(:listing, Re.Listing)
+    belongs_to(:user, Re.User)
+
+    timestamps()
+  end
+
+  @required ~w(listing_id)a
+  @optional ~w(user_id details)a
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required ++ @optional)
+    |> validate_required(@required)
+  end
+end

--- a/lib/re/stats/listing_visualization.ex
+++ b/lib/re/stats/listing_visualization.ex
@@ -7,7 +7,7 @@ defmodule Re.Stats.ListingVisualization do
   import Ecto.Changeset
 
   schema "listing_visualizations" do
-    field(:details, :map)
+    field(:details, :string)
 
     belongs_to(:listing, Re.Listing)
     belongs_to(:user, Re.User)

--- a/lib/re/stats/visualizations.ex
+++ b/lib/re/stats/visualizations.ex
@@ -1,0 +1,26 @@
+defmodule Re.Stats.Visualizations do
+  alias Re.{
+    Listing,
+    Stats.ListingVisualization,
+    Repo,
+    User
+  }
+
+  def listing(listing, user, _conn) do
+    insert(%{listing_id: listing.id, user_id: user.id})
+  end
+
+  def listing(listing, nil, conn) do
+    insert(%{listing_id: listing.id, details: extract_details(conn)})
+  end
+
+  defp insert(params) do
+    %ListingVisualization{}
+    |> ListingVisualization.changset(params)
+    |> Repo.insert()
+  end
+
+  @conn_params ~w(remote_ip req_headers)a
+
+  defp extract_details(conn), do: Map.take(conn, @conn_params)
+end

--- a/priv/repo/migrations/20180206144040_listing_visualizations.exs
+++ b/priv/repo/migrations/20180206144040_listing_visualizations.exs
@@ -5,7 +5,7 @@ defmodule Re.Repo.Migrations.ListingVisualizations do
     create table(:listing_visualizations) do
       add(:listing_id, references(:listings))
       add(:user_id, references(:users))
-      add(:details, :map)
+      add(:details, :text)
 
       timestamps()
     end

--- a/priv/repo/migrations/20180206144040_listing_visualizations.exs
+++ b/priv/repo/migrations/20180206144040_listing_visualizations.exs
@@ -1,0 +1,16 @@
+defmodule Re.Repo.Migrations.ListingVisualizations do
+  use Ecto.Migration
+
+  def change do
+    create table(:listing_visualizations) do
+      add(:listing_id, references(:listings))
+      add(:user_id, references(:users))
+      add(:details, :map)
+
+      timestamps()
+    end
+
+    create(index(:listing_visualizations, [:listing_id]))
+    create(index(:listing_visualizations, [:user_id]))
+  end
+end

--- a/test/re/stats/listing_visualization_test.exs
+++ b/test/re/stats/listing_visualization_test.exs
@@ -24,7 +24,7 @@ defmodule Re.ListingVisualizationTest do
     changeset =
       ListingVisualization.changeset(%ListingVisualization{}, %{
         listing_id: listing.id,
-        details: %{something: "something"}
+        details: "some details"
       })
 
     assert changeset.valid?

--- a/test/re/stats/listing_visualization_test.exs
+++ b/test/re/stats/listing_visualization_test.exs
@@ -1,0 +1,37 @@
+defmodule Re.ListingVisualizationTest do
+  use Re.ModelCase
+
+  alias Re.Stats.ListingVisualization
+
+  import Re.Factory
+
+  test "changeset with user_id" do
+    listing = insert(:listing)
+    user = insert(:user)
+
+    changeset =
+      ListingVisualization.changeset(%ListingVisualization{}, %{
+        listing_id: listing.id,
+        user_id: user.id
+      })
+
+    assert changeset.valid?
+  end
+
+  test "changeset without user_id" do
+    listing = insert(:listing)
+
+    changeset =
+      ListingVisualization.changeset(%ListingVisualization{}, %{
+        listing_id: listing.id,
+        details: %{something: "something"}
+      })
+
+    assert changeset.valid?
+  end
+
+  test "changeset with invalid attributes" do
+    changeset = ListingVisualization.changeset(%ListingVisualization{}, %{})
+    refute changeset.valid?
+  end
+end

--- a/test/re/stats/visualizations_test.exs
+++ b/test/re/stats/visualizations_test.exs
@@ -1,0 +1,33 @@
+defmodule Re.VisualizationsTest do
+  use Re.ModelCase
+
+  alias Re.{
+    Stats.Visualizations,
+    Stats.ListingVisualization
+  }
+
+  import Re.Factory
+
+  describe "listing/1" do
+    test "should insert listing visualization with user" do
+      listing = insert(:listing)
+      user = insert(:user)
+      Visualizations.listing(listing, user)
+      :timer.sleep(500)
+      assert [%{listing_id: _, user_id: _}] = Repo.all(ListingVisualization)
+    end
+
+    test "should insert listing visualization without user" do
+      %{id: id} = listing = insert(:listing)
+      Visualizations.listing(listing, nil, %{something: "something", more: %{another_thing: 1}})
+      :timer.sleep(500)
+
+      assert [
+               %{
+                 listing_id: ^id,
+                 details: %{"something" => "something", "more" => %{"another_thing" => 1}}
+               }
+             ] = Repo.all(ListingVisualization)
+    end
+  end
+end

--- a/test/re/stats/visualizations_test.exs
+++ b/test/re/stats/visualizations_test.exs
@@ -6,28 +6,29 @@ defmodule Re.VisualizationsTest do
     Stats.ListingVisualization
   }
 
+  import ExUnit.CaptureLog
   import Re.Factory
 
-  describe "listing/1" do
+  describe "`handle_cast/2" do
     test "should insert listing visualization with user" do
-      listing = insert(:listing)
-      user = insert(:user)
-      Visualizations.listing(listing, user)
-      :timer.sleep(500)
-      assert [%{listing_id: _, user_id: _}] = Repo.all(ListingVisualization)
+      %{id: listing_id} = listing = insert(:listing)
+      %{id: user_id} = user = insert(:user)
+      Visualizations.handle_cast({:listing_user, listing.id, user.id}, [])
+
+      assert [%{listing_id: ^listing_id, user_id: ^user_id}] = Repo.all(ListingVisualization)
     end
 
     test "should insert listing visualization without user" do
-      %{id: id} = listing = insert(:listing)
-      Visualizations.listing(listing, nil, %{something: "something", more: %{another_thing: 1}})
-      :timer.sleep(500)
+      %{id: listing_id} = listing = insert(:listing)
+      Visualizations.handle_cast({:listing_anon, listing.id, "something"}, [])
 
-      assert [
-               %{
-                 listing_id: ^id,
-                 details: %{"something" => "something", "more" => %{"another_thing" => 1}}
-               }
-             ] = Repo.all(ListingVisualization)
+      assert [%{listing_id: ^listing_id, details: "something"}] = Repo.all(ListingVisualization)
+    end
+
+    test "should not insert visualization without listing" do
+      assert capture_log(fn ->
+               Visualizations.handle_cast({:listing_user, -1, "something"}, [])
+             end) =~ "Listing visualization was not inserted: "
     end
   end
 end

--- a/test/support/test_visualizations.ex
+++ b/test/support/test_visualizations.ex
@@ -1,3 +1,4 @@
 defmodule Re.TestVisualizations do
+  @moduledoc false
   def listing(_, _, _), do: :ok
 end

--- a/test/support/test_visualizations.ex
+++ b/test/support/test_visualizations.ex
@@ -1,0 +1,3 @@
+defmodule Re.TestVisualizations do
+  def listing(_, _, _), do: :ok
+end


### PR DESCRIPTION
- Added a GenServer to save listing views without interrupting main process
- Mock the server for integration testing
- Save either logged in user or `remote_ip` and `req_headers`